### PR TITLE
Not using UITextFieldDelegate to handle letter cut-off

### DIFF
--- a/SeinfeldQuotes/TextInputTableViewCell.swift
+++ b/SeinfeldQuotes/TextInputTableViewCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class TextInputTableViewCell: UITableViewCell, UITextFieldDelegate {
+class TextInputTableViewCell: UITableViewCell {
 
     @IBOutlet weak private var textField: UITextField!
 
@@ -16,7 +16,7 @@ class TextInputTableViewCell: UITableViewCell, UITextFieldDelegate {
     private var textFieldChangedHander: textFieldChangedHandlerType?
     
     override func awakeFromNib() {
-        textField.delegate = self
+        textField.addTarget(self, action: "textFieldValueChanged:", forControlEvents: .EditingChanged)
     }
     
     func configure(#text: String?, placeholder: String, textFieldChangedHandler: textFieldChangedHandlerType?) {
@@ -30,14 +30,9 @@ class TextInputTableViewCell: UITableViewCell, UITextFieldDelegate {
         self.textFieldChangedHander = textFieldChangedHandler
     }
     
-    // MARK: Text Field Delegate
-    
-    func textField(textField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {
-        
+    func textFieldValueChanged(sender: UITextField) {
         if let textFieldChangedHandler = textFieldChangedHander {
-            textFieldChangedHandler(textField.text)
+            textFieldChangedHandler(sender.text)
         }
-        
-        return true
     }
 }


### PR DESCRIPTION
Hi Natasha!

When you were creating a new quote, the last letter would get cut off. So rather than using the shouldChangeCharactersInRange delegate function, I would recommend firing a selector whenever the textField changes. 

This is very similar to what you were doing, but it fixes the bug, _and_ you're not using shouldChangeCharactersInRange function, which is meant for finding out _if_ a textField should change its value. To simply hijack the delegate function, do some additional work, and always return true, feels odd.

Let me know what you think!
